### PR TITLE
Populate empty library.properties architectures field

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=A library to control OVC3860 based  bluetooth audio module.
 paragraph=
 category=Communication
 url=https://github.com/tomaskovacik/OVC3860
-architectures=
+architectures=*
 includes=OVC3860.h


### PR DESCRIPTION
Empty `architectures` field causes the library's examples to appear under File > Examples > INCOMPATIBLE no matter which board is selected.